### PR TITLE
Fix YAML formatting using : instead of =

### DIFF
--- a/gwc-aimee/run-aimoa.sh
+++ b/gwc-aimee/run-aimoa.sh
@@ -8,7 +8,7 @@
 CURRENT=$(pwd)
 cd ..
 AIMOA=$(pwd)
-AIPYTHONENV=$(pwd)/.venv
+AIPYTHONENV=$(pwd)/.env
 # Override by specifying the full path for AI-MOA base directory and Python virtual environment that contains the installed python pre-requisite packages:
 # AIMOA=/opt/ai-moa
 # AIPYTHONENV=/opt/virtualenv/aimoa

--- a/src/config.yaml.example
+++ b/src/config.yaml.example
@@ -92,7 +92,7 @@ llm:
   model: /models/Mistral-7B-Instruct-v0.3.Q8_0.gguf  # Path to the model file being used.
   temperature: 0.1  # Temperature for controlling the randomness of model responses.
   top_p: 0.1  # Top-p sampling for controlling diversity of responses (related to nucleus sampling).
-  llm.log_response = false     # set to true to see LLM output in console
+  llm.log_response: false     # set to true to see LLM output in console
 
 # Lock configuration, to control access to shared resources.
 lock:


### PR DESCRIPTION
lllm.log_response YAML entry should be using a colon : not an = sign.

Also fix for run-aimoa.sh so it sources the default correct python environment directory.